### PR TITLE
Import Column class to fix failing test

### DIFF
--- a/src/Datatables/Datatables.php
+++ b/src/Datatables/Datatables.php
@@ -2,6 +2,7 @@
 
 namespace MClassic\Datatables;
 
+use MClassic\Datatables\Column\Column;
 use MClassic\Datatables\Engine\Legacy;
 use MClassic\Datatables\Engine\Modern;
 use MClassic\Datatables\Engine\ProtocolEngine;


### PR DESCRIPTION
The `ColumnTest::test_adding_and_retrieving_column` test and the `SearchTest::test_search_array_of_data` test were failing because the `\MClassic\Datatables\Column\Column` class wasn't imported in `\MClassic\Datatables\Datatables` before being used in the `\MClassic\Datatables\Datatables::addColumn` method.

This PR fixes that import. Those two tests now pass. The test at `DatatablesTest::test_table_output_totals` is still failing, though.

Cheers!